### PR TITLE
Modify setup.py for not install test files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(name='mikoto',
       author_email='qingfeng@douban.com',
 
       packages=find_packages(exclude=['tests']),
-      include_package_data=True,
       platforms='any',
       install_requires=['Pygments',
                         'chardet',

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='mikoto',
       author='qingfeng',
       author_email='qingfeng@douban.com',
 
-      packages=find_packages(),
+      packages=find_packages(exclude=['tests']),
       include_package_data=True,
       platforms='any',
       install_requires=['Pygments',


### PR DESCRIPTION
安装mikoto没必要把test文件也放进来

顺便, 其实 `include_package_data=True`我觉得也没有必要，因为目前项目没有其他类型的需要的文件
